### PR TITLE
process instance commands in singcvmfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,17 @@ $ singcvmfs -s exec -cip docker://centos:7 ls /cvmfs
 atlas.cern.ch  config-osg.opensciencegrid.org  grid.cern.ch
 $ singcvmfs ls /cvmfs/atlas.cern.ch
 repo
+
+# or using singularity instances:
+$ export SINGCVMFS_REPOSITORIES="grid.cern.ch,atlas.cern.ch"
+$ singcvmfs -s instance start docker://centos:7 myexampleinstance
+$ singcvmfs -s run instance://myexampleinstance ls /cvmfs
+atlas.cern.ch  config-osg.opensciencegrid.org  grid.cern.ch
+$ singcvmfs -s run instance://myexampleinstance ls /cvmfs/atlas.cern.ch
+repo
+$ singcvmfs -s instance stop myexampleinstance
 ```
+
 The first time you run the above it will take a long time as singularity
 downloads the image from dockerhub and cvmfs fills its cache, but
 running it again should be very fast.

--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ drop-in replacement for singularity when it executes containers.
 Put cvmfs repositories to mount comma-separated in a
 `SINGCVMFS_REPOSITORIES` environment variable.  If a configuration
 repository is needed it will be automatically mounted.  Then you can use
-singcvmfs exactly like singularity with one of its exec, run, or shell
-commands (note: it cannot read an image from cvmfs).  For example, once
-you have [made a singcvmfs distribution](#making-the-cvmfs-distribution)
+singcvmfs exactly like singularity with one of its exec, instance, run,
+or shell commands (note: it cannot read an image from cvmfs).  For example,
+once you have [made a singcvmfs distribution](#making-the-cvmfs-distribution)
 the following should work:
 
 ```

--- a/singcvmfs
+++ b/singcvmfs
@@ -120,12 +120,21 @@ while [ $# -gt 0 ]; do
 done
 
 SINGCMD=""
+SINGINSTCMD=""
 case "$1" in
     version)
         exec singularity $SINGGLOBALOPTS "$@"
         ;;
     version|exec|run|shell)
         SINGCMD="$1"
+        shift
+        SINGCVMFS_IMAGE="" # just in case it is set
+        ;;
+    instance)
+        SINGCMD="$1"
+        shift
+        # consume subcommand for instance
+        SINGINSTCMD=$1
         shift
         SINGCVMFS_IMAGE="" # just in case it is set
         ;;
@@ -138,6 +147,12 @@ case "$1" in
         ;;
 esac
 
-$EXEC singularity $SINGGLOBALOPTS $SINGCMD \
-    -S /var/run/cvmfs -B $CACHEDIR:/var/lib/cvmfs \
-    "${MOUNT_ARGS[@]}" ${SINGCVMFS_SINGOPTS[@]} $SINGCVMFS_IMAGE "$@"
+if [ "$SINGCMD" = instance -a "$SINGINSTCMD" != start ];
+then
+    $EXEC singularity $SINGGLOBALOPTS $SINGCMD $SINGINSTCMD "$@"
+else
+    $EXEC singularity $SINGGLOBALOPTS $SINGCMD $SINGINSTCMD \
+        -S /var/run/cvmfs -B $CACHEDIR:/var/lib/cvmfs \
+        "${MOUNT_ARGS[@]}" ${SINGCVMFS_SINGOPTS[@]} $SINGCVMFS_IMAGE "$@"
+fi
+

--- a/singcvmfs
+++ b/singcvmfs
@@ -15,11 +15,12 @@ Usage: singcvmfs [-V] [global options] [command]
     global options: singularity global options (prior to its command)
     If command starts with one of these singularity commands
         exec
+        instance
         run
         shell
         version
     then the entire command is passed directly to singularity along
-    with options to mount cvmfs repositories.
+    with options to mount cvmfs repositories when appropiate.
     Otherwise the command is a shell command to run inside the chosen
     container image, which may contain whitespace.
     If command is missing then the shell is run.


### PR DESCRIPTION
I need to run a singularity `instance` command with singcvmfs.  The problem is that `singularity instance start` should be treated as a `singularity run` (that is `instance start` should be not separated), and any other sub-commands to `singularity instance` should not receive any of the `run` options.

This commit parses the sub-command to `instance` and passes the `run` options as necessary.