### PR TITLE
Use OSG 3.6 in makedist

### DIFF
--- a/makedist
+++ b/makedist
@@ -130,7 +130,7 @@ case $1 in
         if [ "$EL" = 6 ]; then
             REL=3.4
         else
-            REL=3.5
+            REL=3.6
         fi
         URL="https://repo.opensciencegrid.org/osg/$REL/el$EL/release/$ARCH";;
     egi)


### PR DESCRIPTION
We have both cvmfs-config-osg and cvmfs-x509-helper in the OSG 3.6 repos so we should take those packages from 3.6 instead of 3.5.