### PR TITLE
Fix checking for incorrect version of libfuse on el9

### DIFF
--- a/makedist
+++ b/makedist
@@ -111,7 +111,11 @@ case $1 in
         BASENAME=cvmfsexec
         TOOLS="cvmfsexec mountrepo umountrepo"
         SEDOPTS=""
-        NEEDLIB=libfuse.so.2
+        if [ "$EL" -lt 9 ]; then
+            NEEDLIB=libfuse.so.2
+        else
+            NEEDLIB=libfuse3.so.3
+        fi
         REQUIRES="makedist (without -s)"
         if $SING; then
             BASENAME=singcvmfs


### PR DESCRIPTION
When creating a self-contained distribution, `makedist` checks for `libfuse3.so.3`. On EL9, it should be checking for `libfuse3.so.3` instead.