### PR TITLE
Fix mountrepo for the case when no config repo is defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- Support a `none` build for no cvmfs-config
 - Fix mountrepo for the case where a config repo is not set.
 - Fix fuse3-libs package repo on EL8 when building for singcvmfs.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- Fix mountrepo for the case where a config repo is not set.
 - Fix fuse3-libs package repo on EL8 when building for singcvmfs.
 
 cvmfsexec-4.30 - 6 February 2023

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ expected to be in a `dist` subdirectory under where the scripts are.  The
 easiest way to create the dist directory is to use `makedist`.  It takes a
 parameter of `osg`, `egi`, or `default` to download the latest cvmfs and
 configuration rpm from one of those three sources. Note: `egi` does not
-currently provide rpms for RHEL8 or 9.
+currently provide rpms for RHEL8 or 9. Additionally, specifying `none`
+will download from the `default` source but exclude the
+`cvmfs-config-default` package.
 
 By default a distribution for `cvmfsexec` and `mountrepo/umountrepo` is
 created.  To instead make a distribution for `singcvmfs`, add the `-s`

--- a/cvmfsexec
+++ b/cvmfsexec
@@ -113,9 +113,11 @@ fi
 shift
 
 # Add the config repo if not already asked for
-CONFIG_REPO="`grep -h '^CVMFS_CONFIG_REPOSITORY=' $HERE/dist/etc/cvmfs/default.d/*.conf 2>/dev/null|tail -1|sed 's/^CVMFS_CONFIG_REPOSITORY=//'`"
-if [[ " $REPOS " != *" $CONFIG_REPO "* ]]; then
-    REPOS="$CONFIG_REPO $REPOS"
+if [ -n "`find $HERE/etc/cvmfs/default.d -name "*.conf" 2>/dev/null`" ]; then
+    CONFIG_REPO="`grep -h '^CVMFS_CONFIG_REPOSITORY=' $HERE/dist/etc/cvmfs/default.d/*.conf 2>/dev/null|tail -1|sed 's/^CVMFS_CONFIG_REPOSITORY=//'`"
+    if [[ " $REPOS " != *" $CONFIG_REPO "* ]]; then
+        REPOS="$CONFIG_REPO $REPOS"
+    fi
 fi
 
 MOUNTED_REPOS=""

--- a/makedist
+++ b/makedist
@@ -10,7 +10,7 @@ SUPPORTEDTYPES="rhel7-x86_64 rhel8-x86_64 rhel8-ppc64le rhel9-x86_64 suse15-x86_
 usage()
 {
     (
-    echo "Usage: makedist [-s] [ -m machinetype ] {osg|egi|default}"
+    echo "Usage: makedist [-s] [ -m machinetype ] {osg|egi|none|default}"
     echo "       makedist [-s] -o <self_extracting_script>"
     echo " The first usage creates a distribution in 'dist' directory."
     echo "   The -m option selects machinetype for the distribution."
@@ -156,7 +156,7 @@ case $1 in
     egi)
         OS=centos$EL
         URL="https://repository.egi.eu/sw/production/umd/4/$OS/x86_64/updates";;
-    default)
+    default|none)
         URL="https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$EL/x86_64";;
     *) usage;;
 esac
@@ -223,7 +223,10 @@ if [ "$DISTRO" = "suse" ]; then
     PKGS=""
 fi
 
-PKGS="$PKGS `echo "$LIST"|grep "^cvmfs-config-$DISTTYPE-[0-9]"|tail -1`"
+if [ "$DISTTYPE" != "none" ]; then
+    PKGS="$PKGS `echo "$LIST"|grep "^cvmfs-config-$DISTTYPE-[0-9]"|tail -1`"
+fi
+
 if $INCLUDEHELPER; then
     PKGS="$PKGS `echo "$LIST"|grep "^cvmfs-x509-helper-[0-9]"|tail -1`"
 fi

--- a/mountrepo
+++ b/mountrepo
@@ -40,9 +40,8 @@ fi
 HERE="$(cd `dirname $0` && pwd)"
 DIST="$HERE/dist"
 
-if [ ! -f $DIST/usr/bin/cvmfs2 ] || \
-      [ -z "`find $DIST/etc/cvmfs/default.d -name "*.conf" 2>/dev/null`" ]; then
-    echo "$DIST should be rpm2cpio of cvmfs + config rpm" >&2
+if [ ! -f $DIST/usr/bin/cvmfs2 ] || [ ! -f $DIST/etc/cvmfs/default.conf ]; then
+    echo "$DIST should be rpm2cpio of cvmfs rpm" >&2
     exit 1
 fi
 
@@ -80,14 +79,19 @@ relocate()
 
 DOMAIN="`echo "$REPO"|cut -d. -f2-`"
 (
-CONFIG_REPO="`sed -n 's/^CVMFS_CONFIG_REPOSITORY=//p' $DIST/etc/cvmfs/default.d/*.conf`"
+DEFD_FILES="`find $DIST/etc/cvmfs/default.d -name "*.conf" 2>/dev/null`"
+if [ -n "$DEFD_FILES" ]; then
+    CONFIG_REPO="`sed -n 's/^CVMFS_CONFIG_REPOSITORY=//p' $DIST/etc/cvmfs/default.d/*.conf`"
+fi
 # these are used in some configuration repository includes, set them
 #   for procsource
 CVMFS_CONFIG_REPOSITORY=$CONFIG_REPO
 CVMFS_MOUNT_DIR=$DIST/cvmfs
 
 relocate $DIST/etc/cvmfs/default.conf
-relocate $DIST/etc/cvmfs/default.d/*.conf
+if [ -n "$DEFD_FILES" ]; then
+    relocate $DIST/etc/cvmfs/default.d/*.conf
+fi
 if [ -n "$CONFIG_REPO" -a "$REPO" != "$CONFIG_REPO" ]; then
     relocate $DIST/cvmfs/$CONFIG_REPO/etc/cvmfs/default.conf
 fi

--- a/mountrepo
+++ b/mountrepo
@@ -88,7 +88,7 @@ CVMFS_MOUNT_DIR=$DIST/cvmfs
 
 relocate $DIST/etc/cvmfs/default.conf
 relocate $DIST/etc/cvmfs/default.d/*.conf
-if [ "$REPO" != "$CONFIG_REPO" ]; then
+if [ -n "$CONFIG_REPO" -a "$REPO" != "$CONFIG_REPO" ]; then
     relocate $DIST/cvmfs/$CONFIG_REPO/etc/cvmfs/default.conf
 fi
 
@@ -107,12 +107,12 @@ if ! grep -q "^CVMFS_CACHE_BASE=" $DEFLOCAL 2>/dev/null && [ -d /e2fs ]; then
     echo "CVMFS_CACHE_BASE=/e2fs/cvmfscache"
 fi
 
-if [ "$REPO" != "$CONFIG_REPO" ]; then
+if [ -n "$CONFIG_REPO" -a "$REPO" != "$CONFIG_REPO" ]; then
     relocate $DIST/cvmfs/$CONFIG_REPO/etc/cvmfs/domain.d/$DOMAIN.conf
 fi
 relocate $DIST/etc/cvmfs/domain.d/$DOMAIN.conf
 relocate $DIST/etc/cvmfs/domain.d/$DOMAIN.local
-if [ "$REPO" != "$CONFIG_REPO" ]; then
+if [ -n "$CONFIG_REPO" -a "$REPO" != "$CONFIG_REPO" ]; then
     REPOCONF=$DIST/cvmfs/$CONFIG_REPO/etc/cvmfs/config.d/$REPO.conf
     if [ "$REPO" = oasis.opensciencegrid.org ]; then
         # OASIS_CERTIFICATES is one special variable we do not want relocated


### PR DESCRIPTION
Fixes #68.

Per our discussion on #68, I did [initially include `cvmfs-config-none`](https://github.com/natefoo/cvmfsexec/tree/none-test), but found that it's unnecessary, because the `cvmfs-config-none` package is empty (that is, it contains no files or scripts), it just provides `cvmfs-config` to satisfy the dependency from the `cvmfs` package, which is irrelevant in this case since we're not actually installing the packages with yum/dnf.