### PR TITLE
Fix makedist -o on el9 to have correct and portable check for previously made distributions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+- Fix makedist -o when cross-building between el9 and non-el9 hosts so
+  that it doesn't need to be passed the -m option again to match what
+  was given to makedist without -o.  It also was not able to distinguish
+  on el9 between distributions that had been made with and without -s.
+
 cvmfsexec-4.33 - 11 June 2023
 - Add rhel8-aarch64 machine type.
 - Avoid error messages from extra attempted downloads of the fuse2 library

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+cvmfsexec-4.34 - 21 June 2023
 - Fix makedist -o when cross-building between el9 and non-el9 hosts so
   that it doesn't need to be passed the -m option again to match what
   was given to makedist without -o.  It also was not able to distinguish

--- a/cvmfsexec
+++ b/cvmfsexec
@@ -9,7 +9,7 @@
 #set -x
 #PS4='c$$+ '
 
-VERSION=4.33
+VERSION=4.34
 
 usage()
 {

--- a/makedist
+++ b/makedist
@@ -111,20 +111,21 @@ case $1 in
         BASENAME=cvmfsexec
         TOOLS="cvmfsexec mountrepo umountrepo"
         SEDOPTS=""
-        if [ "$EL" -lt 9 ]; then
-            NEEDLIB=libfuse.so.2
-        else
-            NEEDLIB=libfuse3.so.3
-        fi
         REQUIRES="makedist (without -s)"
         if $SING; then
             BASENAME=singcvmfs
             TOOLS="singcvmfs cvmfs2-wrapper"
             SEDOPTS="-e s/cvmfsexec/$BASENAME/"
-            NEEDLIB=libfuse3.so.3
             REQUIRES="makedist -s"
         fi
-        if [ ! -f $DIST/usr/lib*/$NEEDLIB ] && [ ! -f $DIST/lib*/$NEEDLIB ]; then
+        DISTLIB=libcvmfs_fuse.so
+        SINGLIB=libcvmfs_fuse3.so
+        HASSINGLIB=false
+        if [ -f $DIST/usr/lib*/$SINGLIB ] || [ -f $DIST/lib*/$SINGLIB ]; then
+            HASSINGLIB=true
+        fi
+        if ([ ! -f $DIST/usr/lib*/$DISTLIB ] && [ ! -f $DIST/lib*/$DISTLIB ]) \
+                || [ $SING != $HASSINGLIB ]; then
             echo "Must be run from where cvmfs distribution was made by $REQUIRES" >&2
             exit 1
         fi

--- a/singcvmfs
+++ b/singcvmfs
@@ -3,7 +3,7 @@
 #   with the singularity --fusemount option.
 # Written by Dave Dykstra March 2020
 
-VERSION=4.33
+VERSION=4.34
 
 ME="`basename $0`"
 


### PR DESCRIPTION
And update to 4.34