### PR TITLE
Add `SINGCVMFS_LOGDIR`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+- Add the variable SINGCVMFS_LOGDIR to override the location of the
+  cvmfs logs.
+
 cvmfsexec-4.42 - 24 September 2024
 - Add rhel9-aarch64 and rhel9-ppc64le machine types.
 - In makedist help, split machine types from different distributions

--- a/README.md
+++ b/README.md
@@ -352,3 +352,7 @@ $ truncate -s 6G scratch.img
 $ mkdir -p tmp/shared
 $ mkfs.ext3 -F -O ^has_journal -d tmp scratch.img
 ```
+
+By default the cvmfs logs are written to a top-level `log` directory, alongside
+the top-level `dist` directory. The variable `SINGCVMFS_LOGDIR` can be used to
+write them to a different directory, which will be created if it doesn't exist.

--- a/singcvmfs
+++ b/singcvmfs
@@ -40,6 +40,7 @@ Optional environment variables:
     SINGCVMFS_OPTSFILE      CVMFS options file (default.local)
                             - should set at least CVMFS_HTTP_PROXY
     SINGCVMFS_SINGOPTS      Extra singularity command options
+    SINGCVMFS_LOGDIR        Directory for the cvmfs logs
     SINGCVMFS_LOGLEVEL      Set to debug to enable cvmfs debugging
 !EOF!
     exit 1
@@ -103,7 +104,11 @@ fi
 
 echo "CVMFS_NFILES=`ulimit -Hn`" >etc/cvmfs/default.d/00-nfiles.conf
 echo "CVMFS_USYSLOG=/var/log/cvmfs/@fqrn@.log" >etc/cvmfs/default.d/00-usyslog.conf
-LOGDIR=$HERE/log
+if [ -n "$SINGCVMFS_LOGDIR" ]; then
+  LOGDIR=$SINGCVMFS_LOGDIR
+else
+  LOGDIR=$HERE/log
+fi
 mkdir -p $LOGDIR
 SINGULARITY_BINDPATH="$SINGULARITY_BINDPATH,$LOGDIR:/var/log/cvmfs"
 


### PR DESCRIPTION
Add the variable `SINGCVMFS_LOGDIR` to override the location of the cvmfs logs.