### PR TITLE
Move osg base URL, update to 4.43

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+cvmfsexec-4.43 - 6 January 2025
+- Adjust the URL for downloading osg packages after the layout changed.
 - Add the variable SINGCVMFS_LOGDIR to override the location of the
   cvmfs logs.
 

--- a/cvmfsexec
+++ b/cvmfsexec
@@ -9,7 +9,7 @@
 #set -x
 #PS4='c$$+ '
 
-VERSION=4.42
+VERSION=4.43
 
 usage()
 {

--- a/makedist
+++ b/makedist
@@ -179,11 +179,13 @@ case $1 in
     osg)
         if [ $EL -lt 8 ]; then
             REL=3.6
+            EXT=""
         else
             REL=23-main
+            EXT="/Packages/c"
         fi
         REPO=release
-        BASEURL="https://repo.opensciencegrid.org/osg/$REL/el$EL/$REPO/x86_64";;
+        BASEURL="https://repo.opensciencegrid.org/osg/$REL/el$EL/$REPO/x86_64$EXT";;
     egi)
         OS=centos$EL
         BASEURL="https://repository.egi.eu/sw/production/umd/4/$OS/x86_64/updates";;

--- a/singcvmfs
+++ b/singcvmfs
@@ -3,7 +3,7 @@
 #   with the singularity --fusemount option.
 # Written by Dave Dykstra March 2020
 
-VERSION=4.42
+VERSION=4.43
 
 ME="`basename $0`"
 


### PR DESCRIPTION
The base URL for el8 & el9 in osg 23-main and 24-main yum/dnf repositories changed today to include `Packages/x` in the URL for each package, where `x` is the first character of the package name.  Luckily makedist only needs to download packages beginning with one letter (`c`) from the osg repositories so it is a simple change.